### PR TITLE
Read xdim and ydim from footer

### DIFF
--- a/spe2py.py
+++ b/spe2py.py
@@ -44,13 +44,12 @@ class SpeFile:
                 'This version of spe2py cannot load filetype SPE v. %.1f' % self.header_version
 
             self.nframes = read_at(file, 1446, 2, np.uint16)[0]
-            self.xdim = read_at(file, 42, 2, np.uint16)[0]
-            self.ydim = read_at(file, 656, 2, np.uint16)[0]
 
             self.footer = self._read_footer(file)
             self.dtype = self._get_dtype(file)
 
             # Note: these methods depend on self.footer
+            self.xdim, self.ydim = self._get_dims()
             self.roi, self.nroi = self._get_roi_info()
             self.wavelength = self._get_wavelength()
 
@@ -133,6 +132,15 @@ class SpeFile:
 
         return wavelength
 
+    def _get_dims(self):
+        """
+        Returns the x and y dimensions for each region as stored in the XML footer
+        """
+        xdim = [block["width"] for block in self.footer.SpeFormat.DataFormat.DataBlock.DataBlock]
+        ydim = [block["height"] for block in self.footer.SpeFormat.DataFormat.DataBlock.DataBlock]
+
+        return (xdim, ydim)
+
     def _get_coords(self):
         """
         Returns x and y pixel coordinates. Used in cases where xdim and ydim do not reflect image dimensions
@@ -170,8 +178,8 @@ class SpeFile:
                     data_xdim = len(self.xcoord[region])
                     data_ydim = len(self.ycoord[region])
                 else:
-                    data_xdim = np.asarray(self.xdim, np.uint32)
-                    data_ydim = np.asarray(self.ydim, np.uint32)
+                    data_xdim = np.asarray(self.xdim[region], np.uint32)
+                    data_ydim = np.asarray(self.ydim[region], np.uint32)
                 data[frame][region] = np.fromfile(file, self.dtype, data_xdim * data_ydim).reshape(data_ydim, data_xdim)
         return data
 

--- a/spe2py.py
+++ b/spe2py.py
@@ -30,7 +30,6 @@ def get_files(mult=False):
 
 
 class SpeFile:
-
     def __init__(self, filepath=None):
         if filepath is not None:
             assert isinstance(filepath, str), 'Filepath must be a single string'
@@ -136,8 +135,8 @@ class SpeFile:
         """
         Returns the x and y dimensions for each region as stored in the XML footer
         """
-        xdim = [block["width"] for block in self.footer.SpeFormat.DataFormat.DataBlock.DataBlock]
-        ydim = [block["height"] for block in self.footer.SpeFormat.DataFormat.DataBlock.DataBlock]
+        xdim = [int(block["width"]) for block in self.footer.SpeFormat.DataFormat.DataBlock.DataBlock]
+        ydim = [int(block["height"]) for block in self.footer.SpeFormat.DataFormat.DataBlock.DataBlock]
 
         return (xdim, ydim)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -53,7 +53,7 @@ class BasicFileLoading(unittest.TestCase):
         obj = spe.SpeFile(os.path.join(os.path.dirname(__file__), "test_files/step_and_glue.spe"))
         self.assert_(obj is not None)
         self.assert_(obj.data is not None)
-        self.assert_(obj.data[0][0].shape == (1567, 1024), "Shape read as: {0}".format(obj.data[0][0].shape))
+        self.assert_(obj.data[0][0].shape == (1024, 1567), "Shape read as: {0}".format(obj.data[0][0].shape))
         self.assert_(obj.nframes == 1)
         self.assert_(obj.nroi == 1)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -49,6 +49,14 @@ class BasicFileLoading(unittest.TestCase):
         self.assertEqual(obj.nframes, 10)
         self.assertEqual(obj.nroi, 2)
 
+    def test_load_step_and_glue(self):
+        obj = spe.SpeFile(os.path.join(os.path.dirname(__file__), "test_files/step_and_glue.spe"))
+        self.assert_(obj is not None)
+        self.assert_(obj.data is not None)
+        self.assert_(obj.data[0][0].shape == (1567, 1024))
+        self.assert_(obj.nframes == 1)
+        self.assert_(obj.nroi == 1)
+
 
 class ImagingFunctionality(unittest.TestCase):
     """Test two imaging methods (specplot and image)"""

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,7 +10,7 @@ class BasicFileLoading(unittest.TestCase):
         obj = spe.SpeFile(os.path.join(os.path.dirname(__file__), "test_files/full_sensor_image.spe"))
         self.assert_(obj is not None)
         self.assert_(obj.data is not None)
-        self.assert_(obj.data[0][0].shape == (1024, 1024))
+        self.assert_(obj.data[0][0].shape == (1024, 1024), "Shape read as: {0}".format(obj.data[0][0].shape))
         self.assert_(obj.nframes == 1)
         self.assert_(obj.nroi == 1)
 
@@ -18,7 +18,7 @@ class BasicFileLoading(unittest.TestCase):
         obj = spe.SpeFile(os.path.join(os.path.dirname(__file__), "test_files/small_roi.spe"))
         self.assert_(obj is not None)
         self.assert_(obj.data is not None)
-        self.assert_(obj.data[0][0].shape == (638, 705))
+        self.assert_(obj.data[0][0].shape == (638, 705), "Shape read as: {0}".format(obj.data[0][0].shape))
         self.assertEqual(obj.nframes, 1)
         self.assertEqual(obj.nroi, 1)
 
@@ -27,8 +27,8 @@ class BasicFileLoading(unittest.TestCase):
                                        "test_files/two_rectangular_rois_different_binning.spe"))
         self.assert_(obj is not None)
         self.assert_(obj.data is not None)
-        self.assert_(obj.data[0][0].shape == (638, 705))
-        self.assert_(obj.data[0][1].shape == (55, 80))
+        self.assert_(obj.data[0][0].shape == (638, 705), "Shape read as: {0}".format(obj.data[0][0].shape))
+        self.assert_(obj.data[0][1].shape == (55, 80), "Shape read as: {0}".format(obj.data[0][0].shape))
         self.assertEqual(obj.roi[0]['xBinning'], '1')
         self.assertEqual(obj.roi[1]['xBinning'], '4')
         self.assertEqual(obj.roi[1]['yBinning'], '2')
@@ -37,15 +37,15 @@ class BasicFileLoading(unittest.TestCase):
         obj = spe.SpeFile(os.path.join(os.path.dirname(__file__), "test_files/one_dimensional_spectrum.spe"))
         self.assert_(obj is not None)
         self.assert_(obj.data is not None)
-        self.assert_(obj.data[0][0].shape == (1, 1024))
+        self.assert_(obj.data[0][0].shape == (1, 1024), "Shape read as: {0}".format(obj.data[0][0].shape))
 
     def test_load_complex_file(self):
         obj = spe.SpeFile(os.path.join(os.path.dirname(__file__),
                                        "test_files/ten_frames_two_rois_different_binning.spe"))
         self.assert_(obj is not None)
         self.assert_(obj.data is not None)
-        self.assert_(obj.data[0][0].shape == (177, 626))
-        self.assert_(obj.data[0][1].shape == (46, 256))
+        self.assert_(obj.data[0][0].shape == (177, 626), "Shape read as: {0}".format(obj.data[0][0].shape))
+        self.assert_(obj.data[0][1].shape == (46, 256), "Shape read as: {0}".format(obj.data[0][0].shape))
         self.assertEqual(obj.nframes, 10)
         self.assertEqual(obj.nroi, 2)
 
@@ -53,7 +53,7 @@ class BasicFileLoading(unittest.TestCase):
         obj = spe.SpeFile(os.path.join(os.path.dirname(__file__), "test_files/step_and_glue.spe"))
         self.assert_(obj is not None)
         self.assert_(obj.data is not None)
-        self.assert_(obj.data[0][0].shape == (1567, 1024))
+        self.assert_(obj.data[0][0].shape == (1567, 1024), "Shape read as: {0}".format(obj.data[0][0].shape))
         self.assert_(obj.nframes == 1)
         self.assert_(obj.nroi == 1)
 


### PR DESCRIPTION
This changes xdim and ydim to be read from the footer instead of the header. This is necessary for working with step-and-glue images as the xdim read from the header maxes out at the sensor width, while the footer xdim correctly contains the full image width (which can be wider than the sensor).

Also adds more informative unittest errors if an image fails to be read correctly.