### PR TITLE
Fixes a bug when tkinter uses matplotlib

### DIFF
--- a/spe2py.py
+++ b/spe2py.py
@@ -7,6 +7,8 @@ import untangle
 import tkinter as tk
 from tkinter import filedialog as fdialog
 from io import StringIO
+import matplotlib
+matplotlib.use("TkAgg")
 from matplotlib import pyplot as plt
 
 


### PR DESCRIPTION
See: https://stackoverflow.com/questions/32019556/matplotlib-crashing-tkinter-application

My specific error was:
```
2016-11-28 14:23:59.713 python[1489:75502] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSApplication _setup:]: unrecognized selector sent to instance 0x1004af3f0'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff8da4903c __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x00007fff9180176e objc_exception_throw + 43
	2   CoreFoundation                      0x00007fff8da4c0ad -[NSObject(NSObject) doesNotRecognizeSelector:] + 205
	3   CoreFoundation                      0x00007fff8d991e24 ___forwarding___ + 1028
	4   CoreFoundation                      0x00007fff8d991998 _CF_forwarding_prep_0 + 120
	5   libtk8.5.dylib                      0x0000000107d8f76d TkpInit + 472
	6   libtk8.5.dylib                      0x0000000107d07f91 Initialize + 1541
	7   _tkinter.cpython-35m-darwin.so      0x0000000107bd3ded Tcl_AppInit + 77
	8   _tkinter.cpython-35m-darwin.so      0x0000000107bd17f9 _tkinter_create + 889
	9   libpython3.5m.dylib                 0x00000001000679d9 PyCFunction_Call + 233
	10  libpython3.5m.dylib                 0x00000001000f4cd7 PyEval_EvalFrameEx + 36647
	11  libpython3.5m.dylib                 0x00000001000f5900 _PyEval_EvalCodeWithName + 2400
	12  libpython3.5m.dylib                 0x00000001000f5a07 PyEval_EvalCodeEx + 71
	13  libpython3.5m.dylib                 0x00000001000426ba function_call + 186
	14  libpython3.5m.dylib                 0x000000010000de63 PyObject_Call + 99
	15  libpython3.5m.dylib                 0x000000010002b12c method_call + 140
	16  libpython3.5m.dylib                 0x000000010000de63 PyObject_Call + 99
	17  libpython3.5m.dylib                 0x0000000100080cc1 slot_tp_init + 81
	18  libpython3.5m.dylib                 0x000000010007b964 type_call + 212
	19  libpython3.5m.dylib                 0x000000010000de63 PyObject_Call + 99
	20  libpython3.5m.dylib                 0x00000001000edb9c PyEval_EvalFrameEx + 7660
	21  libpython3.5m.dylib                 0x00000001000f5900 _PyEval_EvalCodeWithName + 2400
	22  libpython3.5m.dylib                 0x00000001000f3c75 PyEval_EvalFrameEx + 32453
	23  libpython3.5m.dylib                 0x00000001000f5900 _PyEval_EvalCodeWithName + 2400
	24  libpython3.5m.dylib                 0x00000001000f3c75 PyEval_EvalFrameEx + 32453
	25  libpython3.5m.dylib                 0x00000001000f5900 _PyEval_EvalCodeWithName + 2400
	26  libpython3.5m.dylib                 0x00000001000f5a61 PyEval_EvalCode + 81
	27  libpython3.5m.dylib                 0x00000001001247ee PyRun_FileExFlags + 206
	28  libpython3.5m.dylib                 0x0000000100124a8f PyRun_SimpleFileExFlags + 447
	29  libpython3.5m.dylib                 0x000000010013d497 Py_Main + 3479
	30  python                              0x0000000100000e92 main + 418
	31  python                              0x0000000100000cc4 start + 52
	32  ???                                 0x0000000000000002 0x0 + 2
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```