### PR TITLE
Add handling for WavelengthError (when Wavelength is not present due to a calibration)

### DIFF
--- a/spe2py.py
+++ b/spe2py.py
@@ -158,11 +158,25 @@ class SpeFile:
         try:
             wavelength_string = StringIO(self.footer.SpeFormat.Calibrations.WavelengthMapping.Wavelength.cdata)
         except AttributeError:
-            print("XML Footer was not loaded prior to calling _get_wavelength")
-            raise
+            """
+            possibly because a calibration is present.
+            Try getting the WavelengthError.cdata instead of Wavelength.cdata when calibration is present.
+            """
+            try:
+                wavelengthErrorStr = self.footer.SpeFormat.Calibrations.WavelengthMapping.WavelengthError.cdata
+                wavelengthErrorStrStream = StringIO(wavelengthErrorStr.replace(" ", "\n"))
+                wavelengthError = np.loadtxt(wavelengthErrorStrStream, delimiter=',')
+                return wavelengthError[:,0]
+            except:
+                print("XML Footer was not loaded prior to calling _get_wavelength")
+                return None
         except IndexError:
             print("XML Footer does not contain Wavelength Mapping information")
-            return
+            raise
+
+
+
+
 
         wavelength = np.loadtxt(wavelength_string, delimiter=',')
 

--- a/spe2py.py
+++ b/spe2py.py
@@ -169,10 +169,10 @@ class SpeFile:
                 return wavelengthError[:,0]
             except:
                 print("XML Footer was not loaded prior to calling _get_wavelength")
-                return None
+                return
         except IndexError:
             print("XML Footer does not contain Wavelength Mapping information")
-            raise
+            return
 
 
 


### PR DESCRIPTION
I noticed that we had a problem reading the wavelengths after doing a wavelength calibration on our pylon camera. Turns out the Wavelength field is not present but WavelengthError is there. Added another try except in the exception when Wavelength is not found.